### PR TITLE
update postcss-import to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "csswring": "^2.0.0",
     "postcss-custom-properties": "^2.0.0",
     "postcss-custom-media": "^1.0.0",
-    "postcss-import": "^2.0.0",
+    "postcss-import": "^4.0.0",
     "postcss-calc": "^2.0.0",
     "postcss-color": "^1.0.0",
     "autoprefixer-core": "^4.0.0",


### PR DESCRIPTION
By updating postcss-import to version 4, it is possible to `@import` files in a manner similar to how [rework-npm](https://github.com/reworkcss/rework-npm) does.

Basically, instead of needing to do:
```
@import 'normalize.css/normalize.css';
```

It is possible to do:
```
@import 'normalize.css';
```

More detailed information is available [here](https://github.com/postcss/postcss-import/issues/7)

Cheers!