### PR TITLE
MQPacker does not have a .processor method

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,7 +49,7 @@ Pleeease.prototype.process = function (css) {
         (opts = this.opts.rem)                   ? rem.apply(null, opts).postcss : false,
         (opts = this.opts.pseudoElements)        ? pseudoElements.processor      : false,
         (opts = this.opts.opacity)               ? opacity.processor             : false,
-        (opts = this.opts.mqpacker)              ? mqpacker.processor            : false,
+        (opts = this.opts.mqpacker)              ? mqpacker.postcss              : false,
         (opts = this.opts.autoprefixer)          ? prefixer(opts).postcss        : false,
         (opts = this.opts.minifier)              ? minifier(opts).postcss        : false
     ];


### PR DESCRIPTION
This fixes an issue where media queries would not be packed even if the
mqpacker option was set to true, which was also causing two specs to fail.