### PR TITLE
Fix broken output when pleeease-cli gives pleeease.parse AST data

### DIFF
--- a/lib/pleeease.js
+++ b/lib/pleeease.js
@@ -25,28 +25,33 @@ var Pleeease = function (options) {
 /**
  *
  * Parse stylesheets
- * @param  {String} css
+ * @param  {String|Object} unprocessed - CSS in string form or AST
  * @return {Object} PostCSS AST
  *
  */
-Pleeease.prototype.parse = function (css) {
+Pleeease.prototype.parse = function (unprocessed) {
 
   var opts = this.options;
 
-  if (opts.sass || opts.less || opts.stylus) {
-    var preprocess = new Preprocessor(css, opts);
+  // Sass etc. don't understand AST format
+  if (typeof unprocessed === 'string' && (opts.sass || opts.less || opts.stylus)) {
+    var preprocess = new Preprocessor(unprocessed, opts);
+
     // Sass
     if (opts.sass) {
       preprocess = preprocess.sass();
     }
+
     // LESS
     if (opts.less) {
       preprocess = preprocess.less();
     }
+
     // Stylus
     if (opts.stylus) {
       preprocess = preprocess.stylus();
     }
+
     // add previous map and switch from and to
     if (opts.sourcemaps) {
       if (opts.sourcemaps.map) {
@@ -54,7 +59,8 @@ Pleeease.prototype.parse = function (css) {
       }
       opts.sourcemaps.from = opts.sourcemaps.to;
     }
-    css = preprocess.css;
+
+    unprocessed = preprocess.css;
   }
 
   var sourcemaps = opts.sourcemaps;
@@ -64,28 +70,27 @@ Pleeease.prototype.parse = function (css) {
     };
   }
 
-  return postcss.parse(css, sourcemaps);
-
+  return postcss.parse(unprocessed, sourcemaps);
 };
 
 /**
  *
  * Process stylesheet (parse, then process)
- * @param  {String} css
+ * @param  {String|Object} unprocessed
  * @return {Promise}
  *
  */
-Pleeease.prototype.process = function (css) {
+Pleeease.prototype.process = function (unprocessed) {
 
   var processor = this;
   var opts = processor.options;
 
   return new Promise(function (resolve, reject) {
-    if (!css) {
-      reject(new Error('CSS missing in pleeease.process()'));
+    if (!unprocessed) {
+      reject(new Error('CSS string or CSS AST data was not provided to pleeease.process()'));
     }
     try {
-      resolve(processor.parse(css));
+      resolve(processor.parse(unprocessed));
     } catch (err) {
       reject(err);
     }

--- a/test/pleeease.js
+++ b/test/pleeease.js
@@ -41,7 +41,7 @@ describe('Pleeease', function () {
       done('should not run');
     }).catch(function (error) {
       error.should.be.an.instanceOf(Error);
-      error.should.have.property('message', 'CSS missing in pleeease.process()');
+      error.should.have.property('message', 'CSS string or CSS AST data was not provided to pleeease.process()');
       done();
     }).catch(done);
   });
@@ -51,7 +51,7 @@ describe('Pleeease', function () {
       done('should not run');
     }, function (error) {
       error.should.be.an.instanceOf(Error);
-      error.should.have.property('message', 'CSS missing in pleeease.process()');
+      error.should.have.property('message', 'CSS string or CSS AST data was not provided to pleeease.process()');
       done();
     }).catch(done);
   });


### PR DESCRIPTION
In cli ._compile, AST is given to pleeease.parse, which the preprocessors
don't understand. Therefore we need to skip over them and go straight to
PostCSS for final processing.

I also renamed a few variables for clarity.